### PR TITLE
Modified the YT-downloader script

### DIFF
--- a/Youtube-To-MP3.user.js
+++ b/Youtube-To-MP3.user.js
@@ -3,42 +3,30 @@
 // @name           Youtube-To-MP3
 // @version        0.8
 // @namespace      Youtube-To-MP3
-// @author         dufferZafar
+// @author         dufferZafar, rootavish
 // @description    Download MP3 from a youtube video
 // @include        *//www.youtube.com/*
 // @run-at         document-end
 // ==/UserScript==
-
-GM_log("Youtube-To-Mp3 Started");
-
-var subs = document.getElementsByClassName('yt-uix-button-subscription-container')[0]
-// Stylize
-var btnCSS = document.createElement("style");
-btnCSS.type = "text/css";
-btnCSS.innerHTML = ".mp3btn {margin-left: 10px;}"
+GM_log('Youtube-To-Mp3 Started');
+var subs = document.getElementsByClassName('yt-uix-button-subscription-container') [0]
+// Stylize  
+var btnCSS = document.createElement('style');
+btnCSS.type = 'text/css';
+btnCSS.innerHTML = '.mp3btn {margin-left: 10px;}'
 document.body.appendChild(btnCSS);
-
-var downSpan = document.createElement("span");
-downSpan.classList.add("yt-uix-button-group");
-downSpan.classList.add("mp3btn");
-
-var downLink = document.createElement("a");
+var downSpan = document.createElement('span');
+downSpan.classList.add('yt-uix-button-group');
+downSpan.classList.add('mp3btn');
+var downLink = document.createElement('a');
 downLink.innerHTML = '<span class="yt-uix-button-content">Download MP3</span>'
-downLink.target = "blank";
+downLink.target = '_blank';
 downLink.href = "http://youtubeinmp3.com/fetch/?video=" + document.URL
-downLink.classList.add("yt-uix-button");
-downLink.classList.add("yt-uix-button-reverse");
-downLink.classList.add("yt-uix-button-default");
-
+downLink.classList.add('yt-uix-button');
+downLink.classList.add('yt-uix-button-reverse');
+downLink.classList.add('yt-uix-button-default');
 downSpan.appendChild(downLink)
 subs.parentNode.insertBefore(downSpan, subs.nextSibling);
-
-/*
-Todo: This is the part that still needs to be done.
-
-1.) Send a XHR request to youtubeinmp3.com's API, there's a direct download link in their json response.
-2.) downLink.href = DIRECT_DOWNLOAD_LINK
-*/
 
 //simple XHR request in pure JavaScript
 function xhrLoad(url, callback)
@@ -48,22 +36,24 @@ function xhrLoad(url, callback)
     xhr.onreadystatechange = ensureReadiness;
     function ensureReadiness()
     {
-        if(xhr.readyState < 4)
-            return;
-
-        if(xhr.status !== 200)
-            return;
-
+        if (xhr.readyState < 4)
+        return ;
+        if (xhr.status !== 200)
+        return ;
         // all is well
-        if(xhr.readyState === 4) {
+        if (xhr.readyState === 4) {
             callback(xhr);
         }
     }
     xhr.open('GET', url, true);
-    xhr.send('');
+    xhr.send(null);
+    var responseJson = xhr.response;
+    for (var p in responseJson)
+    {
+        downLink.href = p['link'];
+    }
 }
-
-xhrLoad("http://youtubeinmp3.com/fetch/?api=advanced&format=JSON&video="+document.URL, function(xhr) {
+xhrLoad('http://youtubeinmp3.com/fetch/?api=advanced&format=JSON&video=' + document.URL, function (xhr) {
     var result = xhr.responseText;
     console.log(result);
 });


### PR DESCRIPTION
What it does:
For some songs it does work as expected and opens the dialog prompt: watch?v=0KSOMA3QBU0
For others, it redirects me to their "convert and download page", even though the response JSON has the link for that: watch?v=450p7goxZqg
For a possible third scenario, it redirects me to a page with a converted video, instead of initiating the download
Also, even in the cases where it works, it does, even though for an instant only though, open a new tab and then close it, although that may be because I did not give the request any parameters. That is because I got nothing from the "send()" function's documentation.
This is obviously because of my limited knowledge of JavaScript. So please fix this when you have time.
