### PR TITLE
Replace eval() with JSON.parse()

### DIFF
--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -61,8 +61,7 @@ if (m = /^https?:\/\/itunes.apple.com\/(?:([a-z]{2})\/)?album\/(?:[^\/]+\/)?id([
 function callbackFunction(req) {
     if (xmlhttp.readyState != 4)
         return;
-    var r = eval('(' + xmlhttp.responseText + ')');
-//  var r = $.parseJSON(xmlhttp.responseText);
+    var r = JSON.parse(xmlhttp.responseText);
 
     for (var i = 0; i < r.results.length; i++) {
         if (r.results[i].wrapperType == "collection") {

--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        MusicBrainz: Import from iTunes
 // @description Import releases from iTunes
-// @version     2014-06-21
+// @version     2017-06-12
 // @author      -
 // @namespace   http://github.com/dufferzafar/Userscripts
 //


### PR DESCRIPTION
Fixes #8. Not sure why the $.parseJSON() line was commented out, but apparently it is [deprecated](http://api.jquery.com/jQuery.parseJSON/) with jQuery 3.0, so I replaced both lines with its successor.

Error fixed:
```
Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' *.apple.com".


    at callbackFunction (<anonymous>:70:45)
    at XMLHttpRequest.xmlhttp.onreadystatechange (<anonymous>:63:47)
```