### PR TITLE
Stop adding copyright info to label field

### DIFF
--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -83,8 +83,6 @@ function callbackFunction(req) {
     add_field("date.day", day);
     add_field("country", country);
     add_field("status", "official");
-    //add_field("language", "jpn");
-    //add_field("script", "Jpan");
     add_field("type", type);
     add_field("edit_note", "Imported from: "+ document.location.href +
                           " using https://github.com/dufferzafar/Userscripts/blob/master/MB-Import-From-iTunes.user.js");

--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        MusicBrainz: Import from iTunes
 // @description Import releases from iTunes
-// @version     2017-06-20
+// @version     2017.08.10.0
 // @author      -
 // @namespace   http://github.com/dufferzafar/Userscripts
 //

--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -11,7 +11,7 @@
 //**************************************************************************//
 
 var myform = document.createElement("form");
-var artist = '', album = '', label = '', year = 0, month = 0, day = 0, country = 'XW', type = 'album', discs = 0;
+var artist = '', album = '', year = 0, month = 0, day = 0, country = 'XW', type = 'album', discs = 0;
 
 if (m = /^https?:\/\/itunes.apple.com\/(?:([a-z]{2})\/)?album\/(?:[^\/]+\/)?id([0-9]+)/.exec(document.location.href)) {
     country = m[1];
@@ -44,12 +44,6 @@ function callbackFunction(req) {
                 month = m[2];
                 day = m[3];
             }
-
-            label = r.results[i].copyright;
-            if (m = /(?:[0-9]{4} )?(.*)/.exec(r.results[i].copyright)) {
-                label = m[1];
-            }
-
         } else if (r.results[i].wrapperType === "track") {
             var discno = r.results[i].discNumber - 1;
             var trackno = r.results[i].trackNumber - 1;
@@ -87,7 +81,6 @@ function callbackFunction(req) {
     add_field("date.year", year);
     add_field("date.month", month);
     add_field("date.day", day);
-    add_field("labels.0.name", label);
     add_field("country", country);
     add_field("status", "official");
     //add_field("language", "jpn");


### PR DESCRIPTION
Removed all traces of adding text to the label box, and two commented out lines along with it. Closes #4.

 Also updated version style, because Tampermonkey suggested that the update was a downgrade. Greasemonkey [suggests a syntax](https://wiki.greasespot.net/Metadata_Block#.40version) which is now followed (with dots instead of hyphens). The exact format with the date was borrowed from [murdos/musicbrainz-userscripts](https://github.com/murdos/musicbrainz-userscripts).