### PR TITLE
Change 'purchase for download' to 'streaming page'

### DIFF
--- a/MB-Import-From-iTunes.user.js
+++ b/MB-Import-From-iTunes.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        MusicBrainz: Import from iTunes
 // @description Import releases from iTunes
-// @version     2021.03.01.0
+// @version     2021.10.01.0
 // @author      -
 // @namespace   http://github.com/dufferzafar/Userscripts
 //
@@ -115,7 +115,7 @@ function callbackFunction(responseDetails) {
     add_field("type", type);
     add_field("edit_note", "Imported from: "+ document.location.href +
                           " using https://github.com/dufferzafar/Userscripts/blob/master/MB-Import-From-iTunes.user.js");
-    add_field("urls.0.link_type", "74");
+    add_field("urls.0.link_type", "980");
     add_field("urls.0.url", document.location.href);
 
     // label


### PR DESCRIPTION
There's a specific URL type for streaming services that don't provide free plans, as opposed to 'stream for free'. This is the case for Apple Music.
https://musicbrainz.org/relationship/320adf26-96fa-4183-9045-1f5f32f833cb